### PR TITLE
add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: perl
+sudo: false
+perl:
+ - "5.10" 
+ - "5.12"
+ - "5.14"
+ - "5.16"
+ - "5.18"
+ - "5.20"
+ - "5.22"
+ - "5.24"
+ - "5.26"
+matrix:
+  include:
+    - perl: 5.18
+      env: COVERAGE=1   # enables coverage+coveralls reporting
+addons:
+  apt:
+    packages:
+    - texlive
+    - texlive-latex-extra
+before_install:
+  - eval $(curl https://travis-perl.github.io/init) --auto

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 LaTeX-Driver
 ============
 
+[![Travis Status](https://travis-ci.org/Template-Toolkit-Latex/LaTeX-Driver.svg?branch=master)](https://travis-ci.org/Template-Toolkit-Latex/LaTeX-Driver)
+[![Coverage Status](https://coveralls.io/repos/github/Template-Toolkit-Latex/LaTeX-Driver/badge.svg?branch=master)](https://coveralls.io/github/Template-Toolkit-Latex/LaTeX-Driver?branch=master)
+
 Perl module to drive LaTeX


### PR DESCRIPTION
This is my entry for the Pull Request Challenge 2017 in November.

The commit adds a .travis.yml file, which will enable Travis-CI and coveralls.io support for this project. In case you're not familiar how those work, here's a short description.

Both services are free for open source. You need to make your own account by signing in with your github account. You then sync your github repositories and select the ones you want. A description for the continuous integration system can be found at https://docs.travis-ci.com/user/getting-started, and for the test coverage reports at http://docs.coveralls.io/. 

Travis CI will then run whenever someone sends a PR or you push a commit, and it might send you a ton of emails with reports that you can turn off if you don't want them. There are jobs in Travis for all common Perl versions. One of them will report test coverage statistics to Coveralls, where you can then inspect it in detail.

I've set up both of them for my fork. You can check them out here:
https://travis-ci.org/simbabque/LaTeX-Driver
https://coveralls.io/github/simbabque/LaTeX-Driver

Both of those services have fancy badges that will display directly on github. I've included those in the README.md file, but not in the POD. They will initially show an unknown build because they point to your master branch, which doesn't have the config file yet and is not set up.

If you need help setting these things up or have additional questions, feel free to ask. I consider these very useful tools that help the maintainer as well as other people supplying PRs.